### PR TITLE
Revert removal of positional-only arguments

### DIFF
--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -357,7 +357,7 @@ def _format_incompatible_python_env_message(
 
 
 def execute(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     verbose = args.v
     keydb = args.keydb

--- a/smartsim/_core/_cli/clean.py
+++ b/smartsim/_core/_cli/clean.py
@@ -41,13 +41,13 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 
 
 def execute(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     return clean(get_install_path() / "_core", _all=args.clobber)
 
 
 def execute_all(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     args.clobber = True
     return execute(args)

--- a/smartsim/_core/_cli/dbcli.py
+++ b/smartsim/_core/_cli/dbcli.py
@@ -31,7 +31,7 @@ from smartsim._core._cli.utils import get_db_path
 
 
 def execute(
-    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     if db_path := get_db_path():
         print(db_path)

--- a/smartsim/_core/_cli/info.py
+++ b/smartsim/_core/_cli/info.py
@@ -13,7 +13,7 @@ _MISSING_DEP = _helpers.colorize("Not Installed", "red")
 
 
 def execute(
-    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     print("\nSmart Python Packages:")
     print(

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -8,7 +8,9 @@ from smartsim._core._cli.utils import MenuItemConfig
 
 
 def dynamic_execute(cmd: str) -> t.Callable[[argparse.Namespace, t.List[str]], int]:
-    def process_execute(_args: argparse.Namespace, unparsed_args: t.List[str]) -> int:
+    def process_execute(
+        _args: argparse.Namespace, unparsed_args: t.List[str], /
+    ) -> int:
         not_found = f"{cmd} plugin not found. Please ensure it is installed"
         try:
             spec = importlib.util.find_spec(cmd)
@@ -39,4 +41,5 @@ def dashboard() -> MenuItemConfig:
         is_plugin=True,
     )
 
-plugins = (dashboard, )
+
+plugins = (dashboard,)

--- a/smartsim/_core/_cli/site.py
+++ b/smartsim/_core/_cli/site.py
@@ -30,6 +30,6 @@ import typing as t
 from smartsim._core._cli.utils import get_install_path
 
 
-def execute(_args: argparse.Namespace, _unparsed_args: t.List[str]) -> int:
+def execute(_args: argparse.Namespace, _unparsed_args: t.List[str], /) -> int:
     print(get_install_path())
     return 0

--- a/smartsim/_core/_cli/validate.py
+++ b/smartsim/_core/_cli/validate.py
@@ -83,7 +83,7 @@ class _VerificationTempDir(_TemporaryDirectory):
 
 
 def execute(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     """Validate the SmartSim installation works as expected given a
     simple experiment


### PR DESCRIPTION
Positional-only argument requirements were removed incorrectly from CLI action handlers. This PR adds them back.